### PR TITLE
Notas enteras (sin decimales) en notas examen y en cursada

### DIFF
--- a/econ/operaciones/notas_cursada/pagelet_renglones.php
+++ b/econ/operaciones/notas_cursada/pagelet_renglones.php
@@ -49,5 +49,13 @@ class pagelet_renglones extends \siu\operaciones\notas_cursada\pagelet_renglones
 		$this->add_var_js('msj_navegacion', kernel::traductor()->trans('msj_navegacion'));
     }
 
+
+	function esenteranota($nota)
+	{
+		if (strpos($nota, ',') >0 ){
+			return false;
+		}
+		return true;
+	}
+
 }
-?>

--- a/econ/operaciones/notas_cursada/renglones/default.twig
+++ b/econ/operaciones/notas_cursada/renglones/default.twig
@@ -41,7 +41,7 @@
                                 <span class="nombre">{{nombre}}
                                     {% if alumno.PROMOCIONAL == "S" %}
 										{# <span class="acchide">{{"promocionable" |trans|capitalize}}</span><span class="icon-certificate js-tooltip" title="{{"promocionable" |trans|capitalize}}"></span> #}
-										{# Iris: se cambió el icono que identifica a los promocionables #}
+										{# Iris: se cambiÃ³ el icono que identifica a los promocionables #}
 										<span class="acchide">{{"promocionable" |trans|capitalize}}</span><span class="acepta-icon js-tooltip" title="{{"promocionable" |trans|capitalize}}"></span>
                                         {% if not this.data.encabezado.PROM_ABIERTA %}
                                             <span class="icon-exclamation-sign js-tooltip" title="{{"acta_promocion_cerrada" |trans|capitalize}}"></span>
@@ -49,7 +49,7 @@
                                     {% endif %}
 
 								</span>
-								{# Iris: Se quitó la leyena legajo. No incorporarla porque sino no funciona AUTOCALCULAR #}
+								{# Iris: Se quitÃ³ la leyena legajo. No incorporarla porque sino no funciona AUTOCALCULAR #}
 								{# {{'legajo'|trans|capitalize}}:  #}
 								<span class="legajo">{{ alumno.LEGAJO }}</span>
                             </div>
@@ -95,7 +95,7 @@
                                 or alumno.RESULTADO == 'P'
                                 or (this.data.encabezado.PROM_ABIERTA and alumno.PROMOCIONAL == 'S')
                                 %}
-                                {# nunca se muestra 6. Es la opción 'No promocionó' #}
+                                {# nunca se muestra 6. Es la opciÃ³n 'No promocionÃ³' #}
                                 {% set mostrar_opcion = mostrar_opcion and condicion.COND_REGULARIDAD != 6 %}
 
                                 {% if mostrar_opcion %}
@@ -119,9 +119,11 @@
                         >
                             <option value='' data-resultado='vacio'>{{ '-' }}</option>
                             {% for nota in this.data.escala_notas %}
-                                {% set selected = (alumno.NOTA == nota.DESCRIPCION) ? 'SELECTED' : '' %}
-                                <option {{ selected }} value='{{nota.DESCRIPCION}}'>{{nota.DESCRIPCION}}</option>
-                            {% endfor %}
+                              {% if this.esenteranota(nota.DESCRIPCION) %}
+                                 {% set selected = (alumno.NOTA == nota.DESCRIPCION) ? 'SELECTED' : '' %}
+                                 <option {{ selected }} value='{{nota.DESCRIPCION}}'>{{nota.DESCRIPCION}}</option>
+                              {% endif %}
+							{% endfor %}
                         </select>
                     </td>
 

--- a/econ/operaciones/notas_examen/pagelet_renglones.php
+++ b/econ/operaciones/notas_examen/pagelet_renglones.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace econ\operaciones\notas_examen;
+
+use kernel\kernel;
+use siu\guarani;
+use siu\modelo\datos\catalogo;
+
+class pagelet_renglones extends \siu\operaciones\notas_examen\pagelet_renglones
+{
+	function esenteranota($nota)
+	{
+		if (strpos($nota, ',') >0 ){
+			return false;
+		}
+		return true;
+	}
+
+}

--- a/econ/operaciones/notas_examen/renglones/default.twig
+++ b/econ/operaciones/notas_examen/renglones/default.twig
@@ -1,0 +1,95 @@
+{% extends "kernel/pagelet.twig" %}
+{% block contenido %}
+
+{% if this.hay_renglones %}
+    <form class='form-renglones' action='{{ this.data.url_guardar }}' method='post'>
+        <fieldset>
+        <legend><h4>Completar</h4></legend>
+        {{ _self.barra_acciones(this, 'arriba') }}
+	<table class="tabla-renglones table table-bordered table-condensed" summary="Alumnos para carga de notas">
+	    <thead>
+		<th id="nombre" scope="col">{{ 'nombre_alumno'|trans|capitalize }}</th>
+		<th id="doc" scope="col">{{ 'documento'|trans|capitalize }}</th>
+		<th id="fecha" scope="col">{{ 'fecha_examen'|trans|capitalize }}</th>
+		<th id="condicion" scope="col">{{ 'condicion'|trans|capitalize }}</th>
+		<th id="nota" scope="col">{{ 'nota'|trans|capitalize }}</th>
+		<th id="resultado" scope="col">{{ 'resultado'|trans|capitalize }}</th>
+		<th id="concepto" scope="col">{{ 'concepto'|trans|capitalize }}</th>
+	    </thead>
+
+	    <tbody>
+		{% for alumno in this.data.renglones %}
+		    <tr id='renglon_{{ alumno.RENGLON }}'
+			    class='{{ (alumno.ERROR) ? 'error-renglon' : '' }}'
+			    title='{{ (alumno.ERROR) ? alumno.ERROR    : '' }}'
+		    >
+			<td headers="nombre" class="col-alumno">
+				<div class="ficha-alumno clearfix"
+					data-url-ficha="{{ alumno.URL_FICHA }}">
+					<img src='{{alumno.URL_IMAGEN}}' width='35' height="35" alt='Foto, clic para mostrar ficha' class="pull-left" />
+					<div class="pull-left">
+						<span class="nombre">{{ alumno.NOMBRE }}</span>
+						<span class="legajo">{{'legajo'|trans|capitalize}}: {{ alumno.LEGAJO }}</span>
+					</div>
+				</div>
+			</td>
+			<td headers="doc" class="alinear col-documento">{{ alumno.DOCUMENTO }}</td>
+			<td headers="fecha" class="centrar alinear col-fecha">
+                            <label class="acchide" for="renglones[{{ alumno.RENGLON }}][fecha]">Formato: DD/MM/YYYY</label>
+                            <input id="renglones[{{ alumno.RENGLON }}][fecha]" type='text' data-tipo='fecha' title='Fecha'
+					name='renglones[{{ alumno.RENGLON }}][fecha]' 
+					value='{{ alumno.FECHA }}' 
+					class='fecha nav  {{(error_fecha) ? 'js-error-campo' : ''}}' />
+			</td>
+			<td headers="condicion" class="alinear col-condicion">{{ alumno.TIPO_INSC }}</td>
+			<td headers="nota" class="centrar alinear col-nota">
+			    <label class="acchide" for="renglones[{{ alumno.RENGLON }}][nota]">Nota: de 0 a 10</label>
+                                <select id="renglones[{{ alumno.RENGLON }}][nota]" class='nota' data-tipo='nota' title='Nota' name='renglones[{{ alumno.RENGLON }}][nota]'>
+                                        <optgroup label="Notas">
+                                            <option value='' data-resultado='vacio'>{{ '-' }}</option>
+											{% for nota in this.data.escala_notas %}
+												{% if this.esenteranota(nota.DESCRIPCION) %}
+													{% set selected = (alumno.NOTA == nota.DESCRIPCION) ? 'SELECTED' : '' %}
+													<option {{ selected }} value='{{nota.DESCRIPCION}}'>{{nota.DESCRIPCION}}</option>
+												{% endif %}
+											{% endfor %}
+                                        </optgroup>
+				</select>
+			</td>
+			<td headers="resultado" class='alinear wrapper-resultado col-resultado'><span class='texto'></span>
+				<input type='hidden' 
+					   data-tipo='resultado'
+					   name='renglones[{{ alumno.RENGLON }}][resultado]' 
+					   value=''/>
+			</td>
+			<td headers="concepto" aria-live="assertive" class='concepto alinear col-concepto'></td>
+		    </tr>
+		{% endfor %}
+	    </tbody>
+	</table>
+		{{ _self.barra_acciones(this) }}
+        </fieldset>
+    </form>
+{% else %}
+    <div role="alert" class="alert">{{"no_hay_renglones"|trans|capitalize}}</div>
+{% endif %}
+
+{% endblock %}
+	
+{% macro barra_acciones(pagelet, posicion) %}
+    {% import "kernel/macro_pager.twig" as pager %}
+    <div class="form-actions clearfix">
+		<div class="pagination pagination-small pull-left">
+			{{ pager.render_paginator(pagelet.get_paginas, pagelet.get_pagina_actual, 'folio') }}
+		</div>
+			
+		{% if posicion == 'arriba' %}
+			<div class="form-inline pull-left form-busqueda">
+				<label class="control-label notas_examen_query" for='notas_examen_query'>{{"label_busqueda_alumnos"|trans|capitalize}}
+				<input type='text' id='notas_examen_query' name='query' value='' class="input-small" />
+			</div>
+		{% endif %}
+		
+	    <input type='submit' value='{{"guardar"|trans|capitalize}}' class="btn btn-info btn-small pull-right" />
+    </div>
+{% endmacro %}


### PR DESCRIPTION
Iris, Moises me había pedido que haga esto que me había quedado pendiente. 

Lo que hace es agregar un metodo en los pagelet_renglones de notas_examen y de notas_cursada y en el twig lo usa para forzar en el select solo las notas sin decimales.

Yo en la versión de producción ya lo mergeo, y luego no debería generar conflicto cuando hagamos el merge de producción (pull) en taylor. Sino hacemos el force.